### PR TITLE
Change JIT provisioned Managed profile name

### DIFF
--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/github/GithubAuthenticatorConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/github/GithubAuthenticatorConstants.java
@@ -25,7 +25,7 @@ package org.wso2.carbon.identity.authenticator.github;
 public class GithubAuthenticatorConstants {
 
     public static final String AUTHENTICATOR_NAME = "GithubAuthenticator";
-    public static final String AUTHENTICATOR_FRIENDLY_NAME = "Github";
+    public static final String AUTHENTICATOR_FRIENDLY_NAME = "GitHub";
     // Github authorize endpoint URL.
     public static final String GITHUB_OAUTH_ENDPOINT = "https://github.com/login/oauth/authorize";
     // Github token  endpoint URL.


### PR DESCRIPTION
Related https://github.com/wso2-enterprise/asgardeo-product/issues/5963

Change the `AUTHENTICATOR_FRIENDLY_NAME` constant of GitHub Authenticator as the `GitHub`.