### PR TITLE
Improve the callback url resolving logic for api based authn

### DIFF
--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/github/GithubAuthenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/github/GithubAuthenticator.java
@@ -197,7 +197,7 @@ public class GithubAuthenticator extends OpenIDConnectAuthenticator implements F
             String clientId = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_ID);
             String clientSecret = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_SECRET);
             String tokenEndPoint = getTokenEndpoint(authenticatorProperties);
-            String callbackUrl = getCallbackUrl(authenticatorProperties);
+            String callbackUrl = getCallbackUrl(authenticatorProperties, context);
 
             OAuthAuthzResponse authorizationResponse = OAuthAuthzResponse.oauthCodeAuthzResponse(request);
             String code = authorizationResponse.getCode();
@@ -454,7 +454,7 @@ public class GithubAuthenticator extends OpenIDConnectAuthenticator implements F
      * @param context Authentication context.
      * @return Map of application details.
      */
-    private Map<String, String> getApplicationDetails(AuthenticationContext context) {
+    protected Map<String, String> getApplicationDetails(AuthenticationContext context) {
 
         Map<String, String> applicationDetailsMap = new HashMap<>();
         FrameworkUtils.getApplicationResourceId(context).ifPresent(applicationId ->

--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
         <identity.outbound.auth.oidc.import.version.range>[5.11.18, 6.0.0)</identity.outbound.auth.oidc.import.version.range>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <identity.outbound.auth.oidc.version>5.11.18</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.12.9</identity.outbound.auth.oidc.version>
         <oltu.version>1.0.0.wso2v2</oltu.version>
         <org.apache.oltu.oauth2.client.version>1.0.0</org.apache.oltu.oauth2.client.version>
         <oltu.package.import.version.range>[1.0.0, 2.0.0)</oltu.package.import.version.range>


### PR DESCRIPTION
Use the overloaded `getCallbackUrl` method which loads the redirect url from the authentication context and set it as the callback url instead of taking it from connector properties.

Related issue - https://github.com/wso2/product-is/issues/20173
Merge after - https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/183

Note - Needed to change the access modifier of getApplicationDetails method since it has been changed in the latest identity.outbound.auth.oidc version. 