### PR TITLE
Override getAMRValue method

### DIFF
--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/github/GithubExecutor.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/github/GithubExecutor.java
@@ -63,6 +63,12 @@ public class GithubExecutor extends OpenIDConnectExecutor {
     }
 
     @Override
+    public String getAMRValue() {
+
+        return GithubAuthenticatorConstants.AUTHENTICATOR_NAME;
+    }
+
+    @Override
     public String getAuthorizationServerEndpoint(Map<String, String> authenticatorProperties) {
 
         return GithubAuthenticatorConstants.GITHUB_OAUTH_ENDPOINT;

--- a/pom.xml
+++ b/pom.xml
@@ -267,12 +267,12 @@
         </snapshotRepository>
     </distributionManagement>
     <properties>
-        <carbon.identity.framework.version>7.8.317</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.403</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.25.260, 8.0.0)</carbon.identity.package.import.version.range>
         <identity.outbound.auth.oidc.import.version.range>[5.11.18, 6.0.0)</identity.outbound.auth.oidc.import.version.range>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <identity.outbound.auth.oidc.version>5.12.33</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.12.36</identity.outbound.auth.oidc.version>
         <oltu.version>1.0.0.wso2v2</oltu.version>
         <org.apache.oltu.oauth2.client.version>1.0.0</org.apache.oltu.oauth2.client.version>
         <oltu.package.import.version.range>[1.0.0, 2.0.0)</oltu.package.import.version.range>


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24768

This pull request introduces a new method to support authentication context and updates dependencies to use newer versions. The main changes are grouped below:

Authentication method improvements:

* Added the `getAMRValue()` method to the `GithubExecutor` class, which returns the authenticator name for Authentication Method Reference (AMR) support.

Dependency updates:

* Updated `carbon.identity.framework.version` from `7.8.317` to `7.8.403` in `pom.xml`.
* Updated `identity.outbound.auth.oidc.version` from `5.12.33` to `5.12.36` in `pom.xml`.